### PR TITLE
fix: noticket - when creating indexes do not log untargetted queries

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 6, 4)
+VERSION = (0, 6, 5)

--- a/shardmonster/operations.py
+++ b/shardmonster/operations.py
@@ -27,7 +27,8 @@ def _get_value_by_key(d, key):
     return result
 
 
-def _create_collection_iterator(collection_name, query, with_options={}):
+def _create_collection_iterator(collection_name, query, with_options={},
+                                log_untargetted_queries=True):
     """Creates an iterator that returns collections and queries that can then
     be used to perform multishard operations:
 
@@ -48,7 +49,7 @@ def _create_collection_iterator(collection_name, query, with_options={}):
     else:
         locations = _get_all_locations_for_realm(realm)
         global untargetted_query_callback
-        if untargetted_query_callback:
+        if untargetted_query_callback and log_untargetted_queries:
             untargetted_query_callback(collection_name, query)
 
     for location, location_meta in locations.iteritems():
@@ -491,7 +492,8 @@ def multishard_save(collection_name, doc, with_options={}, *args, **kwargs):
 
 
 def multishard_ensure_index(collection_name, *args, **kwargs):
-    collection_iterator = _create_collection_iterator(collection_name, {})
+    collection_iterator = _create_collection_iterator(
+        collection_name, {}, log_untargetted_queries=False)
 
     for collection, _, _ in collection_iterator:
         collection.ensure_index(*args, **kwargs)

--- a/shardmonster/tests/test_operations.py
+++ b/shardmonster/tests/test_operations.py
@@ -2,6 +2,7 @@ import bson
 from mock import Mock, patch
 from pymongo.cursor import Cursor
 from pymongo.errors import OperationFailure
+from pymongo import ASCENDING
 
 from shardmonster import api, operations
 from shardmonster.tests.base import ShardingTestCase
@@ -569,6 +570,15 @@ class TestStandardMultishardOperations(ShardingTestCase):
         c = operations.multishard_find('dummy', {'a': 1}).sort([('y.z', 1)])
         results = sorted(list(c), key=lambda d: d['x'])
         self.assertEquals([doc1, doc2], results)
+
+    def test_multishard_ensure_index_no_untargetted_query_callback_called(self):
+        _callback = Mock()
+
+        api.set_untargetted_query_callback(_callback)
+
+        operations.multishard_ensure_index('dummy', [('x', ASCENDING)])
+
+        _callback.assert_not_called()
 
 
 class TestOtherOperations(ShardingTestCase):


### PR DESCRIPTION
When creating indexes shardmonster will call the untargetted_query_callback in error, this generates useless log messages during testing and is distracting. This change stops those from being logged.