### PR TITLE
Fix tests and fix broken skip on multishard queries

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 6, 8)
+VERSION = (0, 8, 0)

--- a/shardmonster/metadata.py
+++ b/shardmonster/metadata.py
@@ -91,13 +91,13 @@ class ShardMetadataStore(object):
             self._refresh_all_shard_metadata()
         elif self._in_flux:
             self._refresh_single_shard_metadata(self._in_flux)
-            
+
         return {
             shard_key: metadata for
             shard_key, (metadata, _) in self._cache.iteritems()
         }
 
-    
+
     def _refresh_single_shard_metadata(self, shard_key):
         global _caching_timeout
         shards = list(self._query_shards_collection(shard_key))
@@ -202,7 +202,7 @@ def _get_metadata_for_shard(realm, shard_key):
 def _get_all_locations_for_realm(realm):
     """Gets all the locations for the given realm. The results will be of the
     form:
-    
+
         { location: LocationMetadata(...) }
 
     The excludes is a list of keys that need to be excluded from any query

--- a/shardmonster/operations.py
+++ b/shardmonster/operations.py
@@ -82,11 +82,9 @@ class MultishardCursor(object):
         self._skip = 0
         self._explains = []
 
-
     def _create_collection_iterator(self):
         return _create_collection_iterator(
             self.collection_name, self.query, self.with_options)
-
 
     def _prepare_for_iteration(self):
         # The multishard cursor has to keep track of a surprising amount of
@@ -123,33 +121,26 @@ class MultishardCursor(object):
         self._explains.append((location, cursor.explain))
         self._current_cursor = cursor
 
-
     def __iter__(self):
         return self
 
-
     def __len__(self):
         return self.count()
-
 
     def next(self):
         res = self._next()
         return res
 
-
     def _next(self):
         if not self._prepared:
             self.evaluate()
-
         safe_skip = self._skip or 0
 
         if not self._targetted:
             while self._skipped < safe_skip:
                 self._skipped += 1
                 self._next_result()
-
         return self._next_result()
-
 
     def _next_result(self):
         """Gets the next result from any cache or cursors available. Ignores
@@ -171,16 +162,13 @@ class MultishardCursor(object):
                 else:
                     raise
 
-
     def limit(self, limit):
         self.kwargs['limit'] = limit
         return self
 
-
     def skip(self, skip):
         self._skip = skip
         return self
-
 
     def sort(self, key_or_list, direction=None):
         if direction:
@@ -189,12 +177,10 @@ class MultishardCursor(object):
             self.kwargs['sort'] = key_or_list
         return self
 
-
     def clone(self):
         return MultishardCursor(
             self.collection_name, self.query, _hint=self._hint,
             *self.args, **self.kwargs)
-
 
     def __getitem__(self, i):
         if isinstance(i, int):
@@ -250,7 +236,6 @@ class MultishardCursor(object):
             # then applies the limit. Again, correctness over efficiency.
             self._cached_results = list(self)[:self.kwargs['limit']]
 
-
     def count(self, **count_kwargs):
         total = 0
         for collection, query, _ in self._create_collection_iterator():
@@ -263,13 +248,11 @@ class MultishardCursor(object):
         else:
             return total
 
-
     def rewind(self):
         self._cached_results = None
         self._current_cursor = None
         self._queries_pending = None
         self._prepared = False
-
 
     def hint(self, index):
         self._hint = index
@@ -278,7 +261,6 @@ class MultishardCursor(object):
     def batch_size(self, size):
         self.kwargs['batch_size'] = size
         return self
-
 
     @property
     def alive(self):
@@ -401,16 +383,17 @@ def _get_collection_for_targetted_upsert(
     return collection
 
 
-def multishard_update(collection_name, query, update, with_options={}, **kwargs):
+def multishard_update(collection_name, query, update,
+                      with_options={}, **kwargs):
     _wait_for_pause_to_end(collection_name, query)
     overall_result = None
     # If this is an upsert then we check the update to see if it might contain
     # the shard key and use that for the collection iterator. Otherwise,
-    # we can end up doing an upsert against all clusters... which results in lots
-    # of documents all over the place.
+    # we can end up doing an upsert against all clusters... which results in
+    # lots of documents all over the place.
     collection_iterator = None
     if (kwargs.get('upsert', False) and '$set' in update and
-        _get_query_target(collection_name, update['$set'])):
+            _get_query_target(collection_name, update['$set'])):
         # Can't use the normal collection iteration method as it would use the
         # wrong query. Instead, get a specific collection and turn it into the
         # right format.

--- a/shardmonster/tests/test_operations.py
+++ b/shardmonster/tests/test_operations.py
@@ -451,23 +451,26 @@ class TestStandardMultishardOperations(ShardingTestCase):
             'dummy', {}, sort=[('x', 1), ('y', 1)]).skip(4)
         self.assertEquals([], list(results))
 
-    def test_skip_slice(self):
+    def test_can_slice_ordered_data_across_shards(self):
         doc1 = {'x': 1, 'y': 1}
         doc2 = {'x': 2, 'y': 1}
         self.db1.dummy.insert(doc1)
         self.db2.dummy.insert(doc2)
 
-        c = operations.multishard_find('dummy', {'y': 1})[1:]
-        results = sorted(list(c), key=lambda d: d['x'])
-        self.assertEquals([doc2], results)
+        cursor = operations.multishard_find('dummy',
+                                            {'y': 1},
+                                            sort=[('x', 1)])[1:]
+        self.assertEquals([doc2], list(cursor))
 
-    def test_non_zero_indexing(self):
+    def test_can_index_an_item_across_shards(self):
         doc1 = {'x': 1, 'y': 1}
         doc2 = {'x': 2, 'y': 1}
         self.db1.dummy.insert(doc1)
         self.db2.dummy.insert(doc2)
 
-        result = operations.multishard_find('dummy', {'y': 1})[1]
+        result = operations.multishard_find('dummy',
+                                            {'y': 1},
+                                            sort=[('x', 1)])[1]
         self.assertEquals(doc2, result)
 
     def test_skip_beyond_limit(self):
@@ -478,7 +481,9 @@ class TestStandardMultishardOperations(ShardingTestCase):
         expected_doc = {'x': 2, 'y': 1}
         self.db2.dummy.insert(expected_doc)
 
-        result = operations.multishard_find('dummy', {'y': 1}).limit(1).skip(4)
+        result = operations \
+            .multishard_find('dummy', {'y': 1}, sort=[('x', 1)]) \
+            .limit(1).skip(4)
         self.assertEquals([expected_doc], list(result))
 
     def test_getitem_on_non_targetted_query(self):

--- a/shardmonster/tests/test_operations.py
+++ b/shardmonster/tests/test_operations.py
@@ -425,7 +425,7 @@ class TestStandardMultishardOperations(ShardingTestCase):
         c.next()
         self.assertFalse(c.alive)
 
-    def test_multishard_skip(self):
+    def test_skips_earlier_rows_across_shards(self):
         doc1 = {'x': 1, 'y': 1}
         doc2 = {'x': 1, 'y': 2}
         doc3 = {'x': 2, 'y': 1}
@@ -435,21 +435,21 @@ class TestStandardMultishardOperations(ShardingTestCase):
         self.db2.dummy.insert(doc3)
         self.db2.dummy.insert(doc4)
 
-        results = operations.multishard_find(
+        cursor = operations.multishard_find(
             'dummy', {}, sort=[('x', 1), ('y', 1)]).skip(1)
-        self.assertEquals([doc2, doc3, doc4], list(results))
+        self.assertEquals([doc2, doc3, doc4], list(cursor))
 
-        results = operations.multishard_find(
+        cursor = operations.multishard_find(
             'dummy', {}, sort=[('x', 1), ('y', 1)]).skip(2)
-        self.assertEquals([doc3, doc4], list(results))
+        self.assertEquals([doc3, doc4], list(cursor))
 
-        results = operations.multishard_find(
+        cursor = operations.multishard_find(
             'dummy', {}, sort=[('x', 1), ('y', 1)]).skip(3)
-        self.assertEquals([doc4], list(results))
+        self.assertEquals([doc4], list(cursor))
 
-        results = operations.multishard_find(
+        cursor = operations.multishard_find(
             'dummy', {}, sort=[('x', 1), ('y', 1)]).skip(4)
-        self.assertEquals([], list(results))
+        self.assertEquals([], list(cursor))
 
     def test_can_slice_ordered_data_across_shards(self):
         doc1 = {'x': 1, 'y': 1}


### PR DESCRIPTION
This fixes a bug in the skip() behaviour in shardmonster. It was skipping from the first shard rather than the data as a whole. This also includes array range selectors as well.

Also various test fixes.