### PR TITLE
Migration copy tolerates duplicates caused by updates

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 8, 0)
+VERSION = (0, 8, 1)

--- a/shardmonster/api.py
+++ b/shardmonster/api.py
@@ -57,20 +57,20 @@ def ensure_realm_exists(name, shard_field, collection_name, default_dest):
     if cursor.count():
         # realm with this name already exists
         existing = cursor[0]
-        if (existing['shard_field'] != shard_field
-            or existing['collection'] != collection_name
-            or existing['default_dest'] != default_dest):
+        if (existing['shard_field'] != shard_field or
+                existing['collection'] != collection_name or
+                existing['default_dest'] != default_dest):
             raise Exception('Cannot change realm')
         else:
             return
-        
+
     cursor = coll.find({'collection': collection_name})
     if cursor.count():
         # realm for this collection already exists
         existing = cursor[0]
-        if (existing['shard_field'] != shard_field
-            or existing['name'] != name
-            or existing['default_dest'] != default_dest):
+        if (existing['shard_field'] != shard_field or
+                existing['name'] != name or
+                existing['default_dest'] != default_dest):
             raise Exception(
                 'Realm for collection %s already exists' % collection_name)
         else:
@@ -84,7 +84,7 @@ def _assert_valid_location(location):
     # Attempting to get the URI for a non-existant cluster will throw an
     # exception
     get_cluster_uri(cluster_name)
-        
+
 
 def set_shard_at_rest(realm, shard_key, location, force=False):
     """Marks a shard as being at rest in the given location. This is used for
@@ -101,7 +101,7 @@ def set_shard_at_rest(realm, shard_key, location, force=False):
     :return: None
     """
     _assert_valid_location(location)
-    
+
     shards_coll = _get_shards_coll()
 
     query = {'realm': realm, 'shard_key': shard_key}
@@ -110,7 +110,8 @@ def set_shard_at_rest(realm, shard_key, location, force=False):
             'Shard with key %s has already been placed. Use force=true if '
             'you really want to do this' % shard_key)
 
-    shards_coll.update(query,
+    shards_coll.update(
+        query,
         {
             '$set': {
                 'location': location,

--- a/shardmonster/connection.py
+++ b/shardmonster/connection.py
@@ -4,8 +4,7 @@ import threading
 import time
 
 logger = logging.getLogger("shardmonster")
-
-CLUSTER_CACHE_LENGTH = 10 * 60 # Cache URI lookups for 10 minutes
+CLUSTER_CACHE_LENGTH = 10 * 60  # Cache URI lookups for 10 minutes
 
 _connection_cache = {}
 _cluster_uri_cache = {}
@@ -86,7 +85,7 @@ def ensure_cluster_exists(name, uri):
     """Ensures that a cluster with the given name exists. If it doesn't exist,
     a new cluster definition will be created using name and uri. If it does
     exist then no changes will be made.
-    
+
     :param str name: The name of the cluster
     :param str uri: The URI to use for the cluster
     """
@@ -101,6 +100,7 @@ def ensure_cluster_exists(name, uri):
                 "Cluster in database does not match cluster being configured. "
                 "This is normally OK if clusters are being moved about."
             )
+
 
 def get_cluster_uri(name):
     """Gets the URI of the cluster with the given name.

--- a/shardmonster/metadata.py
+++ b/shardmonster/metadata.py
@@ -3,6 +3,7 @@ import time
 from shardmonster.connection import (
     _cluster_uri_cache, _get_cluster_coll, get_controlling_db)
 
+
 class ShardStatus(object):
     def __init__(self):
         raise Exception('Enum. Do not instantiate')
@@ -63,27 +64,22 @@ class ShardMetadataStore(object):
         self._global_timeout = 0
         self._in_flux = None
 
-
     def metadata_changed(self):
         """Call this when metadata is changed. This will flush the cache.
         """
         self._cache = {}
         self._global_timeout = 0
 
-
     def get_single_shard_metadata(self, shard_key):
         if not self._cache_entry_is_valid(shard_key):
             self._refresh_single_shard_metadata(shard_key)
         return self._cache[shard_key][0]
 
-
     def _cache_entry_is_valid(self, shard_key):
         now = time.time()
-        return (
-            self._in_flux != shard_key
-            and shard_key in self._cache
-            and self._cache[shard_key][1] > now)
-
+        return (self._in_flux != shard_key and
+                shard_key in self._cache and
+                self._cache[shard_key][1] > now)
 
     def get_all_shard_metadata(self):
         now = time.time()
@@ -96,7 +92,6 @@ class ShardMetadataStore(object):
             shard_key: metadata for
             shard_key, (metadata, _) in self._cache.iteritems()
         }
-
 
     def _refresh_single_shard_metadata(self, shard_key):
         global _caching_timeout
@@ -114,12 +109,11 @@ class ShardMetadataStore(object):
             self._cache[shard['shard_key']] = (shard, expiry)
         else:
             shard = {
-                'location': _get_realm_by_name(self.collection_name)['default_dest'],
+                'location': _get_realm_by_name(self.collection_name)['default_dest'],  # noqa
                 'status': ShardStatus.AT_REST,
                 'realm': _get_realm_by_name(self.collection_name)['name'],
             }
             self._cache[shard_key] = (shard, generic_expiry)
-
 
     def _refresh_all_shard_metadata(self):
         global _caching_timeout
@@ -137,7 +131,6 @@ class ShardMetadataStore(object):
 
             self._cache[shard['shard_key']] = (shard, expiry)
 
-
     def _query_shards_collection(self, shard_key=None):
         shards_coll = _get_shards_coll()
         query = {'realm': _get_realm_by_name(self.collection_name)['name']}
@@ -153,7 +146,6 @@ class LocationMetadata(object):
         self.location = location
         self.contains = []
         self.excludes = []
-
 
     def __repr__(self):
         contains = ",".join(str(c) for c in self.contains[:5])
@@ -233,7 +225,6 @@ def _get_all_locations_for_realm(realm):
     if realm['default_dest'] not in locations:
         locations[realm['default_dest']] = LocationMetadata(
             realm['default_dest'])
-
 
     return dict(locations)
 

--- a/shardmonster/sharder.py
+++ b/shardmonster/sharder.py
@@ -60,7 +60,7 @@ def _do_copy(collection_name, shard_key, manager):
             counter += 1
             if counter % 100 == 0:
                 raise_last_mongo_error(new_collection.database)
-            manager.tum_ti_tum(manager.insert_throttle)  # Throttle can change in other thread. # noqa
+            tum_ti_tum(manager.insert_throttle)  # Throttle can change in other thread. # noqa
             manager.inc_inserted()
     finally:
         cursor.close()
@@ -183,7 +183,7 @@ def _delete_source_data(collection_name, shard_key, manager):
     try:
         for doc in cursor:
             current_collection.remove({'_id': doc['_id']})
-            manager.tum_ti_tum(manager.delete_throttle)  # Throttle can change in main thread. # noqa
+            tum_ti_tum(manager.delete_throttle)  # Throttle can change in main thread. # noqa
             manager.inc_deleted()
     finally:
         cursor.close()
@@ -312,10 +312,6 @@ class ShardMovementManager(object):
             self.delete_throttle, delete_throttle))
         self.delete_throttle = delete_throttle
 
-    def tum_ti_tum(self, wait_time):
-        if wait_time:
-            time.sleep(wait_time)
-
     def print_status(self):
         if not self.phase:
             log('Migration not started')
@@ -372,3 +368,8 @@ def do_migration(
         collection_name, shard_key, new_location,
         delete_throttle=delete_throttle, insert_throttle=insert_throttle)
     return manager
+
+
+def tum_ti_tum(wait_time):
+    if wait_time:
+        time.sleep(wait_time)


### PR DESCRIPTION
As data is being read in $natural order, updates cause that document to reappear at the later end of the data. These phantoms cause duplicate writes as the data is written to the target shard. In addition, updates are not always correct with lists of embedded documents.

This patch replaces the copy phase insert with an upsert. It also makes all updates copy the current source row as that is canonical.
