### PR TITLE
fix: CON-6541 - Allow migrations to mongos sharded cluster.

### DIFF
--- a/docs/source/developing.rst
+++ b/docs/source/developing.rst
@@ -15,8 +15,13 @@ Update test_settings.py to reflect your local environment. ::
 Running tests inside containers
 -------------------------------
 
-Make sure you have ``docker`` and ``docker-compose`` installed_. From the
-shardmonster directory run:
+Make sure you have ``docker`` and ``docker-compose`` installed. Or...
+
+    > workon docker
+
+...if you haven't and just want to use the conversocial versions.
+
+From the shardmonster directory run:
 
 .. code-block:: bash
 

--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 8, 6)
+VERSION = (0, 8, 7)


### PR DESCRIPTION
If the target of a migration is itself a mongos sharded collection, the upsert during the copy phase needs a full shard key specified in the find clause.