### PR TITLE
DAF-6 — Connect on demand

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -16,6 +16,25 @@ fast.
         "mongodb://localhost:27017/?replicaset=cluster-1",
         "sharding_db"
 
+If you want to delay the connection until the last possible moment, but you
+still want to configure stuff just after the connection is established, you can
+configure the controller without connecting immediately (it will be connected
+on demand), and register a callback that will be invoked just after the
+controller connection is first established:
+
+    import shardmonster
+    from shardmonster import configure_controller
+    from shardmonster.connection import register_post_connect
+
+    @register_post_connect
+    def configure_shardmonster():
+        # e.g.
+        shardmonster.ensure_realm_exists(...)
+
+    shardmonster.configure_controller(
+        "mongodb://localhost:27017/?replicaset=cluster-1", "sharding_db")
+
+
 Activate Caching
 ----------------
 
@@ -71,7 +90,7 @@ aware collection.
     sharded_collection = \
         shardmonster.make_collection_shard_aware("messages")
     sharded_collection.insert({"text": "Hello!", "account": 5})
- 
+
 
 Move some data around
 ---------------------

--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 8, 7)
+VERSION = (0, 8, 8)

--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -1,13 +1,14 @@
 from shardmonster.api import (
-    activate_caching, connect_to_controller, ensure_realm_exists,
-    make_collection_shard_aware, set_shard_at_rest, where_is)
+    activate_caching, connect_to_controller, configure_controller,
+    ensure_realm_exists, make_collection_shard_aware, set_shard_at_rest,
+    where_is)
 from shardmonster.connection import ensure_cluster_exists
 from shardmonster.metadata import wipe_metadata
 from shardmonster.sharder import do_migration
 
 __all__ = [
-    'activate_caching', 'connect_to_controller', 'do_migration',
-    'ensure_cluster_exists', 'ensure_realm_exists',
+    'activate_caching', 'connect_to_controller', 'configure_controller',
+    'do_migration', 'ensure_cluster_exists', 'ensure_realm_exists',
     'make_collection_shard_aware', 'set_shard_at_rest',
     'where_is', 'wipe_metadata', 'VERSION',
 ]

--- a/shardmonster/api.py
+++ b/shardmonster/api.py
@@ -1,6 +1,6 @@
 from shardmonster.connection import (
-    add_cluster, connect_to_controller, _get_cluster_coll, get_cluster_uri,
-    parse_location)
+    add_cluster, connect_to_controller, configure_controller,
+    _get_cluster_coll, get_cluster_uri, parse_location)
 from shardmonster.metadata import (
     _get_location_for_shard, _get_realm_coll, _get_realm_by_name,
     _get_realm_for_collection, _get_shards_coll, ShardStatus, activate_caching,
@@ -8,8 +8,9 @@ from shardmonster.metadata import (
 from shardmonster import operations
 
 __all__ = [
-    "activate_caching", "connect_to_controller", "get_caching_duration",
-    "add_cluster", "set_shard_at_rest", "set_untargetted_query_callback"]
+    "activate_caching", "connect_to_controller", "configure_controller",
+    "get_caching_duration", "add_cluster", "set_shard_at_rest",
+    "set_untargetted_query_callback"]
 
 _collection_cache = {}
 

--- a/shardmonster/tests/test_connection.py
+++ b/shardmonster/tests/test_connection.py
@@ -1,6 +1,51 @@
+import unittest
+
+from mock import Mock, call
+
+import test_settings
+import shardmonster.connection
 from shardmonster.connection import (
-    get_cluster_uri, _get_cluster_coll, ensure_cluster_exists)
+    get_cluster_uri, _get_cluster_coll, ensure_cluster_exists, \
+    register_post_connect, connect_to_controller,
+    configure_controller, get_controlling_db)
 from shardmonster.tests.base import ShardingTestCase
+
+
+class TestCallbacks(unittest.TestCase):
+    """Test post-connect callbacks."""
+
+    def test_post_connect(self):
+        mock_callback = Mock()
+        register_post_connect(mock_callback)
+        connect_to_controller(
+            test_settings.CONTROLLER['uri'],
+            test_settings.CONTROLLER['db_name'],
+        )
+        self.assertEqual([call()], mock_callback.mock_calls)
+
+
+class TestConfigureController(unittest.TestCase):
+
+    def setUp(self):
+        shardmonster.connection._controlling_db = None
+        shardmonster.connection._controlling_db_config = None
+
+    def test_not_configured(self):
+        with self.assertRaises(Exception) as cm:
+            get_controlling_db()
+        self.assertEqual(
+            'Call connect_to_controller or configure_controller '
+            'before attempting to get a connection',
+            str(cm.exception))
+
+    def test_configured(self):
+        configure_controller(
+            test_settings.CONTROLLER['uri'],
+            test_settings.CONTROLLER['db_name'],
+        )
+        self.assertIsNone(shardmonster.connection._controlling_db)
+        get_controlling_db()
+        self.assertIsNotNone(shardmonster.connection._controlling_db)
 
 
 class TestCluster(ShardingTestCase):


### PR DESCRIPTION
- instead of imperative connect to controlling db, just configure it and let the connection happen on demand;
- post-connect callback to carry shardmonster configuration (ensure clusters and realms exist, activate caching, etc)
- now with more backwards compatibility! `connect_to_controller()` still works as before, `configure_controller()` only sets up defaults to try if no explicit call to `connect_to_controller()` has been made