### PR TITLE
 fix: CON-7371 - fix cursor clone with read preference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cover
 .eggs
 .tox
 junit-py27.xml
+.python-version
+.idea/

--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 8, 8)
+VERSION = (0, 8, 9)

--- a/shardmonster/operations.py
+++ b/shardmonster/operations.py
@@ -178,8 +178,13 @@ class MultishardCursor(object):
 
     def clone(self):
         return MultishardCursor(
-            self.collection_name, self.query, _hint=self._hint,
-            *self.args, **self.kwargs)
+            self.collection_name,
+            self.query,
+            _hint=self._hint,
+            with_options=self.with_options,
+            *self.args,
+            **self.kwargs
+        )
 
     def __getitem__(self, i):
         if isinstance(i, int):

--- a/shardmonster/tests/test_operations.py
+++ b/shardmonster/tests/test_operations.py
@@ -2,6 +2,7 @@ import bson
 from mock import Mock, patch
 from pymongo.cursor import Cursor
 from pymongo.errors import OperationFailure
+from pymongo.read_preferences import ReadPreference
 from pymongo import ASCENDING
 
 from shardmonster import api, operations
@@ -101,6 +102,19 @@ class TestStandardMultishardOperations(ShardingTestCase):
         results = operations.multishard_find(
             'dummy', {}, sort=[('x', 1), ('y', 1)], limit=3)
         self.assertEquals([doc1, doc2, doc3], list(results))
+
+    def test_multishard_find_clone_with_read_preference(self):
+        cursor = operations.multishard_find(
+            collection_name='dummy',
+            query={},
+            with_options={
+                'read_preference': ReadPreference.SECONDARY
+            }
+        )
+        cloned_cursor = cursor.clone()
+        self.assertEqual(cloned_cursor.with_options, {
+            'read_preference': ReadPreference.SECONDARY
+        })
 
     def test_multishard_find_one(self):
         r = operations.multishard_find_one('dummy', {'x': 1})

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ skipsdist = True
 
 [testenv]
 commands =
+    mongo --host controller --eval 'rs.initiate()'
+    mongo --host replica --eval 'rs.initiate()'
     python setup.py nosetests --with-xunit --xunit-file=junit-{envname}.xml
 deps =
     mock==1.3.0


### PR DESCRIPTION
Cloning the cursor drops the cursor's read preference and all other options. This PR ensures they're copied into the clone.