### PR TITLE
fix: noticket - remove shard_key from delete operations

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 10, 0)
+VERSION = (0, 10, 1)

--- a/shardmonster/sharder.py
+++ b/shardmonster/sharder.py
@@ -272,7 +272,6 @@ def _delete_source_data(collection_name, shard_key, manager,
             _ids = [record['_id'] for record in batch]
             result = current_collection.delete_many({
                 '_id': {'$in': _ids},
-                realm['shard_field']: shard_key
             })
             tum_ti_tum(manager.delete_throttle)
             manager.inc_deleted(by=result.raw_result['n'])


### PR DESCRIPTION
... to ensure that only the _id index is used.

This should be a completely safe change, we are deleting by _id and
there is already a filter for the shard_key when finding the documents.

This is in place because we have observed mongo picking indexes other
than the _id index to delete documents by. This results in huge index
scans where a single batch of 500 docs takes 20 minutes to delete and
maxes out the read io on the primary.