### PR TITLE
Fix broken migrations & use (shard_field, _id) index to copy if one exists.

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 10, 1)
+VERSION = (0, 10, 2)


### PR DESCRIPTION
* feat: noticket - implement cleanup utility for delete phase
* feat: noticket - implement cleanup utility for failure during copy/sync
* fix: noticket - use (shard_field, _id) index if one exists when reading
    
    When attempting to copy a very large shard the hidden secondary mongo we
    were using started failing AWS instance checks. The exact reason it
    crashed is not well known, however, it is possible that we may have used
    up all of its resources for too long.
    
    Even more speculation here is that might be caused by using a poor index
    when copying. This is an attempt to test out that theory by using a
    (shard_field, _id) index along with a sort and hint.
   

