### PR TITLE
fix: noticket - operator precendence on per second log

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 10, 2)
+VERSION = (0, 10, 3)

--- a/shardmonster/sharder.py
+++ b/shardmonster/sharder.py
@@ -576,7 +576,7 @@ def fix_failed_pre_delete(collection_name, shard_key, delete_batch_size=500,
             now = time.time()
             delta = now - last_print
             if delta >= 120:
-                docs_per_sec = total_deleted - last_total / delta
+                docs_per_sec = (total_deleted - last_total) / float(delta)
                 log("deleted %s docs @ %s/sec" % (total_deleted, docs_per_sec))
                 last_print = now
                 last_total = total_deleted


### PR DESCRIPTION
2019-10-16 15:14:44.918895 deleted 3022500 docs @ 3003738.11386/sec
2019-10-16 15:16:44.928702 deleted 3799500 docs @ 3774314.5581/sec

In [5]: 3799500 - 3022500 / 120.0
Out[5]: 3774312.5

In [6]: (3799500 - 3022500) / 120.0
Out[6]: 6475.0