### PR TITLE
feat: noticket - do not sync from oplog if oplog_ts is not in it

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 10, 3)
+VERSION = (0, 10, 4)


### PR DESCRIPTION
Prior to this it is possible to silently miss oplog updates if the oplog is too small/the copy phase takes too long.

This now fails the migration, it will need to be rolled back.